### PR TITLE
Leave Doppler and loggregator to be routed through LB/gorouter

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -26,28 +26,6 @@ resource "google_dns_record_set" "wildcard-sys-dns" {
   rrdatas = ["${google_compute_global_address.cf.address}"]
 }
 
-resource "google_dns_record_set" "doppler-sys-dns" {
-  name       = "doppler.sys.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
-  type       = "A"
-  ttl        = 300
-
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
-
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
-}
-
-resource "google_dns_record_set" "loggregator-sys-dns" {
-  name       = "loggregator.sys.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
-  type       = "A"
-  ttl        = 300
-
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
-
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
-}
-
 resource "google_dns_record_set" "wildcard-apps-dns" {
   name       = "*.apps.${google_dns_managed_zone.env_dns_zone.dns_name}"
   depends_on = ["google_compute_global_address.cf"]


### PR DESCRIPTION
We found that doppler and loggregator work bettern when their routing is left to gorouter as opposed to being directed by the A record.

Testing in progress.