### PR TITLE
Using the TCP healthcheck for the WS loadbalancer, healthcheck on port 8080 was not working

### DIFF
--- a/router.tf
+++ b/router.tf
@@ -118,7 +118,7 @@ resource "google_compute_target_pool" "cf-ws" {
   name = "${var.env_name}-cf-ws"
 
   health_checks = [
-    "${google_compute_http_health_check.cf-public.name}",
+    "${google_compute_http_health_check.cf-tcp.name}",
   ]
 }
 


### PR DESCRIPTION
from 0.3.0