### PR TITLE
Increase Ops Manager root filesystem size

### DIFF
--- a/ops_manager.tf
+++ b/ops_manager.tf
@@ -45,6 +45,7 @@ resource "google_compute_instance" "ops-manager" {
 
   disk {
     image = "${google_compute_image.ops-manager-image.self_link}"
+    size = 50
   }
 
   network_interface {


### PR DESCRIPTION
We discovered that the default 10G root filesystem size is actually too small to upload an ERT tile to.  You'll kill tempest-web and receive a 502.  50G seems like a more reasonable size for real-world application.