### PR TITLE
Overriding default image create_timeout of 4m with 20m

### DIFF
--- a/ops_manager.tf
+++ b/ops_manager.tf
@@ -54,6 +54,8 @@ resource "google_compute_instance" "ops-manager" {
     access_config {
       # Empty for ephemeral external IP allocation
     }
+
+  create_timeout = 10
   }
 
   service_account {

--- a/ops_manager.tf
+++ b/ops_manager.tf
@@ -22,7 +22,7 @@ resource "google_compute_image" "ops-manager-image" {
     source = "${var.opsman_image_url}"
   }
 
-  create_timeout = 10
+  create_timeout = 20
 }
 
 resource "google_compute_image" "optional-ops-manager-image" {
@@ -33,7 +33,7 @@ resource "google_compute_image" "optional-ops-manager-image" {
     source = "${var.optional_opsman_image_url}"
   }
 
-  create_timeout = 10
+  create_timeout = 20
 }
 
 resource "google_compute_instance" "ops-manager" {


### PR DESCRIPTION
4m is sometimes not enough on us-east1

Signed-off-by: Nitin Ravindran <nravindran@pivotal.io>