### PR TITLE
add timstamp to google sql db name

### DIFF
--- a/ert_sql.tf
+++ b/ert_sql.tf
@@ -8,7 +8,7 @@ resource "google_sql_user" "ert" {
 }
 
 resource "google_sql_database" "uaa" {
-  name       = "uaa"
+  name       = "uaa-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_user.ert"]
 
@@ -16,7 +16,7 @@ resource "google_sql_database" "uaa" {
 }
 
 resource "google_sql_database" "ccdb" {
-  name       = "ccdb"
+  name       = "ccdb-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.uaa"]
 
@@ -24,7 +24,7 @@ resource "google_sql_database" "ccdb" {
 }
 
 resource "google_sql_database" "notifications" {
-  name       = "notifications"
+  name       = "notifications-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.ccdb"]
 
@@ -32,7 +32,7 @@ resource "google_sql_database" "notifications" {
 }
 
 resource "google_sql_database" "autoscale" {
-  name       = "autoscale"
+  name       = "autoscale-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.notifications"]
 
@@ -40,7 +40,7 @@ resource "google_sql_database" "autoscale" {
 }
 
 resource "google_sql_database" "app_usage_service" {
-  name       = "app_usage_service"
+  name       = "app_usage_service-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.autoscale"]
 
@@ -48,7 +48,7 @@ resource "google_sql_database" "app_usage_service" {
 }
 
 resource "google_sql_database" "console" {
-  name       = "console"
+  name       = "console-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.app_usage_service"]
 
@@ -56,7 +56,7 @@ resource "google_sql_database" "console" {
 }
 
 resource "google_sql_database" "diego" {
-  name       = "diego"
+  name       = "diego-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.console"]
 
@@ -64,7 +64,7 @@ resource "google_sql_database" "diego" {
 }
 
 resource "google_sql_database" "routing" {
-  name       = "routing"
+  name       = "routing-${timestamp()}"
   instance   = "${google_sql_database_instance.master.name}"
   depends_on = ["google_sql_database.diego"]
 

--- a/ops_manager_sql.tf
+++ b/ops_manager_sql.tf
@@ -8,7 +8,7 @@ resource "google_sql_user" "opsman-user" {
 }
 
 resource "google_sql_database" "opsman" {
-  name     = "${var.env_name}-db"
+  name     = "${var.env_name}-${timestamp()}"
   instance = "${google_sql_database_instance.master.name}"
 
   count = "${var.opsman_sql_instance_count}"


### PR DESCRIPTION
- gcp often has issues with deleting dbs
- nice to see timestamp to clean out old ones manually