### PR TITLE
google_compute_ssl_certificate uses create_before_destroy

### DIFF
--- a/router.tf
+++ b/router.tf
@@ -74,10 +74,14 @@ resource "google_compute_target_https_proxy" "https_lb_proxy" {
 }
 
 resource "google_compute_ssl_certificate" "cert" {
-  name        = "${var.env_name}-lbcert"
+  name_prefix = "${var.env_name}-lbcert"
   description = "user provided ssl private key / ssl certificate pair"
   private_key = "${var.ssl_cert_private_key}"
   certificate = "${var.ssl_cert}"
+  
+  lifecycle = {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_firewall" "cf-health_check" {


### PR DESCRIPTION
As reported in https://github.com/hashicorp/terraform/issues/10546, google_compute_ssl_certificates that are attached to google_compute_target_https_proxies cannot be updated. This implements the suggested workaround of creating a new certificate before deleting the existing one, and using `name_prefix` instead of `name` so there's no name uniqueness constraints hit.