### PR TITLE
Use heredoc for ssl cert and key in var file instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,20 @@ opsman_image_url = "https://storage.googleapis.com/your-opsmanager.tgz"
 zones = ["us-central1-a", "us-central1-b", "us-central1-c"]
 project = "your-gcp-project"
 dns_suffix = "gcp.some-project.cf-app.com"
-ssl_cert = "-----BEGIN CERTIFICATE-----some cert-----END CERTIFICATE-----\n"
-ssl_cert_private_key = "-----BEGIN RSA PRIVATE KEY-----some cert private key-----END RSA PRIVATE KEY-----\n"
-service_account_key = <<SERVICE_ACCOUNT_KEY
+ssl_cert = <<SSL_CERT
+"
+-----BEGIN CERTIFICATE-----
+some cert
+-----END CERTIFICATE-----
+"
+SSL_CERT
+ssl_cert_private_key = <<SSL_KEY
+"
+-----BEGIN RSA PRIVATE KEY-----
+some cert private key
+-----END RSA PRIVATE KEY-----
+"
+SSL_KEYservice_account_key = <<SERVICE_ACCOUNT_KEY
 {
   "type": "service_account",
   "project_id": "your-gcp-project",


### PR DESCRIPTION
I had a lot of trouble getting gcloud to recognize my ssl cert. Kept getting the following error, until I specified the key and cert using heredoc as described in the PR.

`* google_compute_ssl_certificate.cert: The SSL key could not be parsed.`