### PR TITLE
Make creating Elastic Runtime Cloud Controller's google cloud storage buckets optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ SERVICE_ACCOUNT_KEY
 #### ERT
 - ert_sql_db_host: *(optional)* The host the user can connect from. Can be an IP address. Changing this forces a new resource to be created.
 
+## Elastic Runtime Cloud Controller's Google Cloud Storage Buckets (optional)
+- create_gcs_buckets: *(optional)* When set to "false", buckets will not be created for Elastic Runtime Cloud Controller. Defaults to "true".
+
 ## Running
 
 Note: please make sure you have created the `terraform.tfvars` file above as mentioned.

--- a/storage.tf
+++ b/storage.tf
@@ -1,23 +1,23 @@
 resource "google_storage_bucket" "buildpacks" {
   name          = "${var.env_name}-buildpacks"
   force_destroy = true
-  count         = "${var.create_gcs_buckets}"
+  count         = "${var.create_gcs_buckets ? 1 : 0}"
 }
 
 resource "google_storage_bucket" "droplets" {
   name          = "${var.env_name}-droplets"
   force_destroy = true
-  count         = "${var.create_gcs_buckets}"
+  count         = "${var.create_gcs_buckets ? 1 : 0}"
 }
 
 resource "google_storage_bucket" "packages" {
   name          = "${var.env_name}-packages"
   force_destroy = true
-  count         = "${var.create_gcs_buckets}"
+  count         = "${var.create_gcs_buckets ? 1 : 0}"
 }
 
 resource "google_storage_bucket" "resources" {
   name          = "${var.env_name}-resources"
   force_destroy = true
-  count         = "${var.create_gcs_buckets}"
+  count         = "${var.create_gcs_buckets ? 1 : 0}"
 }

--- a/storage.tf
+++ b/storage.tf
@@ -1,19 +1,23 @@
 resource "google_storage_bucket" "buildpacks" {
   name          = "${var.env_name}-buildpacks"
   force_destroy = true
+  count         = "${var.create_gcs_buckets}"
 }
 
 resource "google_storage_bucket" "droplets" {
   name          = "${var.env_name}-droplets"
   force_destroy = true
+  count         = "${var.create_gcs_buckets}"
 }
 
 resource "google_storage_bucket" "packages" {
   name          = "${var.env_name}-packages"
   force_destroy = true
+  count         = "${var.create_gcs_buckets}"
 }
 
 resource "google_storage_bucket" "resources" {
   name          = "${var.env_name}-resources"
   force_destroy = true
+  count         = "${var.create_gcs_buckets}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,12 @@ variable "iso_seg_ssl_cert_private_key" {
   description = "ssl certificate private key content"
   default     = ""
 }
+
+/********************************
+ * Google Cloud Storage Options *
+ ********************************/
+
+variable "create_gcs_buckets" {
+  description = "create Google Storage Buckets for Elastic Runtime Cloud Controller's file storage"
+  default     = true
+}


### PR DESCRIPTION
Hi!
We would like to make it an option to create Elastic Runtime Cloud Controller's google cloud storage buckets since we prefer to configure our environments with Internal WebDAV. 

However, we would default this option to true so the buckets will get created by default.

- Derwei