### PR TITLE
Makes CIDR blocks a terraform variable

### DIFF
--- a/networks.tf
+++ b/networks.tf
@@ -4,21 +4,21 @@ resource "google_compute_network" "pcf-network" {
 
 resource "google_compute_subnetwork" "management-subnet" {
   name          = "${var.env_name}-management-subnet"
-  ip_cidr_range = "10.0.0.0/24"
+  ip_cidr_range = "${var.management_cidr}"
   network       = "${google_compute_network.pcf-network.self_link}"
   region        = "${var.region}"
 }
 
 resource "google_compute_subnetwork" "ert-subnet" {
   name          = "${var.env_name}-ert-subnet"
-  ip_cidr_range = "10.0.4.0/22"
+  ip_cidr_range = "${var.ert_cidr}"
   network       = "${google_compute_network.pcf-network.self_link}"
   region        = "${var.region}"
 }
 
 resource "google_compute_subnetwork" "services-subnet" {
   name          = "${var.env_name}-services-subnet"
-  ip_cidr_range = "10.0.8.0/22"
+  ip_cidr_range = "${var.services_cidr}"
   network       = "${google_compute_network.pcf-network.self_link}"
   region        = "${var.region}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,24 @@ variable "region" {
   type = "string"
 }
 
+variable "management_cidr" {
+  type = "string"
+  description = "cidr for management subnet"
+  default     = "10.0.0.0/24"
+}
+
+variable "ert_cidr" {
+  type = "string"
+  description = "cidr for ert subnet"
+  default     = "10.0.4.0/24"
+}
+
+variable "services_cidr" {
+  type = "string"
+  description = "cidr for services subnet"
+  default     = "10.0.8.0/24"
+}
+
 variable "zones" {
   type = "list"
 }


### PR DESCRIPTION
We'd like to be able to create a PCF environment with unique subnets as this allows us to easily set up multiple PCF foundations that can be connected via VPC peering