### PR TITLE
Add optional ssl_ca_cert/private_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ SERVICE_ACCOUNT_KEY
 - opsman_image_url **(required)** Source URL of the Ops Manager image you want to boot.
 - service_account_key: **(required)** Contents of your service account key file generated using the `gcloud iam service-accounts keys create` command.
 - dns_suffix: **(required)** Domain to add environment subdomain to (e.g. foo.example.com)
-- ssl_cert: **(required)** SSL certificate for HTTP load balancer configuration. Can be either trusted or self-signed.
-- ssl_private_key:  **(required)** Private key for above SSL certificate.
+- ssl_cert: **(optional)** SSL certificate for HTTP load balancer configuration. Required unless `ssl_ca_cert` is specified.
+- ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `ssl_ca_cert` is specified.
+- ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
+- ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
 - opsman_storage_bucket_count: *(optional)* Google Storage Bucket for BOSH's Blobstore.
 
 ## DNS Records
@@ -108,9 +110,11 @@ SERVICE_ACCOUNT_KEY
 - tcp.*$env_name*.*$dns_suffix*: Points at the TCP load balancer in front of the TCP router.
 
 ## Isolation Segments (optional)
-- isolation_segment *(optional)* When set to "true" creates HTTP load-balancer across 3 zones for isolation segments.
-- iso_seg_ssl_cert: *(optional)* SSL certificate for HTTP load balancer configuration. Can be either trusted or self-signed.
-- iso_seg_ssl_private_key:  *(optional)* Private key for above SSL certificate.
+- isolation_segment **(optional)** When set to "true" creates HTTP load-balancer across 3 zones for isolation segments.
+- iso_seg_ssl_cert: **(optional)** SSL certificate for Iso Seg HTTP load balancer configuration. Required unless `iso_seg_ssl_ca_cert` is specified.
+- iso_seg_ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `iso_seg_ssl_ca_cert` is specified.
+- iso_seg_ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed Iso Seg HTTP load balancer certificate. Required unless `iso_seg_ssl_cert` is specified.
+- iso_seg_ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `iso_seg_ssl_cert` is specified.
 
 ## Cloud SQL Configuration (optional)
 - external_database: *(optional)* When set to "true", a cloud SQL instance will be deployed for the Ops Manager and PAS.

--- a/isolation_segment/outputs.tf
+++ b/isolation_segment/outputs.tf
@@ -1,3 +1,13 @@
 output "load_balancer_name" {
   value = "${element(concat(google_compute_backend_service.isoseg_lb_backend_service.*.name, list("")), 0)}"
 }
+
+output "ssl_cert" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+}
+
+output "ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
+}

--- a/isolation_segment/proxies.tf
+++ b/isolation_segment/proxies.tf
@@ -25,8 +25,8 @@ resource "google_compute_target_https_proxy" "isoseg_https_lb_proxy" {
 resource "google_compute_ssl_certificate" "isoseg_cert" {
   name_prefix = "${var.env_name}-isoseg-lbcert"
   description = "user provided ssl private key / ssl certificate pair"
-  private_key = "${var.ssl_private_key}"
-  certificate = "${var.ssl_cert}"
+  certificate = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+  private_key = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
 
   lifecycle = {
     create_before_destroy = true

--- a/isolation_segment/self_signed_certs.tf
+++ b/isolation_segment/self_signed_certs.tf
@@ -1,0 +1,43 @@
+resource "tls_cert_request" "ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.iso.${var.dns_zone_dns_name}",
+  ]
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.dns_zone_dns_name}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.ssl_ca_private_key}"
+  ca_cert_pem        = "${var.ssl_ca_cert}"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+}

--- a/isolation_segment/variables.tf
+++ b/isolation_segment/variables.tf
@@ -10,6 +10,10 @@ variable "ssl_cert" {}
 
 variable "ssl_private_key" {}
 
+variable "ssl_ca_cert" {}
+
+variable "ssl_ca_private_key" {}
+
 variable "dns_zone_dns_name" {}
 
 variable "dns_zone_name" {}

--- a/modules.tf
+++ b/modules.tf
@@ -22,7 +22,10 @@ module "isolation_segment" {
   ssl_cert        = "${var.iso_seg_ssl_cert}"
   ssl_private_key = "${var.iso_seg_ssl_private_key}"
 
+  ssl_ca_cert        = "${var.iso_seg_ssl_ca_cert}"
+  ssl_ca_private_key = "${var.iso_seg_ssl_ca_private_key}"
+
   dns_zone_name           = "${google_dns_managed_zone.env_dns_zone.name}"
-  dns_zone_dns_name       = "${google_dns_managed_zone.env_dns_zone.dns_name}"
+  dns_zone_dns_name       = "${var.env_name}.${var.dns_suffix}"
   public_healthcheck_link = "${google_compute_http_health_check.cf-public.self_link}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -102,8 +102,28 @@ output "http_lb_backend_name" {
   value = "${google_compute_backend_service.http_lb_backend_service.name}"
 }
 
+output "ssl_cert" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+}
+
+output "ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
+}
+
 output "isoseg_lb_backend_name" {
   value = "${module.isolation_segment.load_balancer_name}"
+}
+
+output "iso_seg_ssl_cert" {
+  sensitive = true
+  value     = "${module.isolation_segment.ssl_cert}"
+}
+
+output "iso_seg_ssl_private_key" {
+  sensitive = true
+  value     = "${module.isolation_segment.ssl_private_key}"
 }
 
 output "ws_router_pool" {

--- a/router.tf
+++ b/router.tf
@@ -80,8 +80,8 @@ resource "google_compute_target_https_proxy" "https_lb_proxy" {
 resource "google_compute_ssl_certificate" "cert" {
   name_prefix = "${var.env_name}-lbcert"
   description = "user provided ssl private key / ssl certificate pair"
-  private_key = "${var.ssl_private_key}"
-  certificate = "${var.ssl_cert}"
+  certificate = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+  private_key = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
 
   lifecycle = {
     create_before_destroy = true

--- a/self_signed_cert.tf
+++ b/self_signed_cert.tf
@@ -1,0 +1,44 @@
+resource "tls_cert_request" "ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.apps.${var.env_name}.${var.dns_suffix}",
+    "*.sys.${var.env_name}.${var.dns_suffix}",
+  ]
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.env_name}.${var.dns_suffix}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.ssl_ca_private_key}"
+  ca_cert_pem        = "${var.ssl_ca_cert}"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,19 +11,19 @@ variable "region" {
 }
 
 variable "management_cidr" {
-  type = "string"
+  type        = "string"
   description = "cidr for management subnet"
   default     = "10.0.0.0/24"
 }
 
 variable "pas_cidr" {
-  type = "string"
+  type        = "string"
   description = "cidr for pas subnet"
   default     = "10.0.4.0/24"
 }
 
 variable "services_cidr" {
-  type = "string"
+  type        = "string"
   description = "cidr for services subnet"
   default     = "10.0.8.0/24"
 }
@@ -58,12 +58,26 @@ variable "dns_suffix" {
 
 variable "ssl_cert" {
   type        = "string"
-  description = "ssl certificate content"
+  description = "the contents of an SSL certificate to be used by the LB, optional if `ssl_ca_cert` is provided"
+  default     = ""
 }
 
 variable "ssl_private_key" {
   type        = "string"
-  description = "ssl certificate private key content"
+  description = "the contents of an SSL private key to be used by the LB, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign the generated LB certificate, optional if `ssl_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign the generated LB certificate, optional if `ssl_cert` is provided"
+  default     = ""
 }
 
 variable "external_database" {
@@ -102,13 +116,25 @@ variable "isolation_segment" {
 
 variable "iso_seg_ssl_cert" {
   type        = "string"
-  description = "ssl certificate content"
+  description = "the contents of an SSL certificate to be used by the LB, optional if `iso_seg_ssl_ca_cert` is provided"
   default     = ""
 }
 
 variable "iso_seg_ssl_private_key" {
   type        = "string"
-  description = "ssl certificate private key content"
+  description = "the contents of an SSL private key to be used by the LB, optional if `iso_seg_ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "iso_seg_ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign the generated iso seg LB certificate, optional if `iso_seg_ssl_cert` is provided"
+  default     = ""
+}
+
+variable "iso_seg_ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign the generated iso seg LB certificate, optional if `iso_seg_ssl_cert` is provided"
   default     = ""
 }
 


### PR DESCRIPTION
Hi Infrastructure team!

This PR adds support for an optional CA cert and key to allow the templates to generate a verifiable certificate for the PAS load balancers. If the CA is not provided, the user must continue to provide the cert/key to use.

Let us know if you have any questions.

@acrmp and @davewalter