### PR TITLE
add PKS support

### DIFF
--- a/modules.tf
+++ b/modules.tf
@@ -29,3 +29,17 @@ module "isolation_segment" {
   dns_zone_dns_name       = "${var.env_name}.${var.dns_suffix}"
   public_healthcheck_link = "${google_compute_http_health_check.cf-public.self_link}"
 }
+
+module "pks" {
+  source = "./pks"
+
+  count = "${var.pks ? 1 : 0}"
+
+  env_name = "${var.env_name}"
+  network_name = "${google_compute_network.pcf-network.name}"
+  zones    = "${var.zones}"
+
+  dns_zone_name           = "${google_dns_managed_zone.env_dns_zone.name}"
+  dns_zone_dns_name       = "${var.env_name}.${var.dns_suffix}"
+
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -197,3 +197,11 @@ output "cf_ws_address" {
 output "dns_managed_zone" {
   value = "${google_dns_managed_zone.env_dns_zone.name}"
 }
+
+output "pks_domain" {
+  value = "${module.pks.domain}"
+}
+
+output "pks_lb_backend_name" {
+  value = "${module.pks.load_balancer_name}"
+}

--- a/pks/dns.tf
+++ b/pks/dns.tf
@@ -1,0 +1,10 @@
+resource "google_dns_record_set" "wildcard-pks-dns" {
+  name  = "*.pks.${var.dns_zone_dns_name}."
+  type  = "A"
+  ttl   = 300
+  count = "${var.count}"
+
+  managed_zone = "${var.dns_zone_name}"
+
+  rrdatas = ["${google_compute_address.pks-api.address}"]
+}

--- a/pks/firewall.tf
+++ b/pks/firewall.tf
@@ -1,0 +1,12 @@
+// Allow access to master node
+resource "google_compute_firewall" "pks-master" {
+  name    = "${var.env_name}-pks-master"
+  network = "${var.network_name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8443"]
+  }
+
+  target_tags = ["master"]
+}

--- a/pks/outputs.tf
+++ b/pks/outputs.tf
@@ -1,0 +1,7 @@
+output "load_balancer_name" {
+  value = "${element(concat(google_compute_target_pool.pks-api.*.name, list("")), 0)}"
+}
+
+output "domain" {
+  value = "${replace(replace(element(concat(google_dns_record_set.wildcard-pks-dns.*.name, list("")), 0), "/^\\*\\./", ""), "/\\.$/", "")}"
+}

--- a/pks/pks_api_router.tf
+++ b/pks/pks_api_router.tf
@@ -1,0 +1,33 @@
+// Allow access to TCP router
+resource "google_compute_firewall" "pks-api" {
+  name    = "${var.env_name}-pks-api"
+  network = "${var.network_name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9021"]
+  }
+
+  target_tags = ["${var.env_name}-pks-api"]
+}
+
+// Static IP address for forwarding rule
+resource "google_compute_address" "pks-api" {
+  name = "${var.env_name}-pks-api"
+}
+
+// TCP target pool
+resource "google_compute_target_pool" "pks-api" {
+  name = "${var.env_name}-pks-api"
+
+  health_checks = []
+}
+
+// TCP forwarding rule
+resource "google_compute_forwarding_rule" "pks-api" {
+  name        = "${var.env_name}-pks-api"
+  target      = "${google_compute_target_pool.pks-api.self_link}"
+  port_range  = "9021"
+  ip_protocol = "TCP"
+  ip_address  = "${google_compute_address.pks-api.address}"
+}

--- a/pks/variables.tf
+++ b/pks/variables.tf
@@ -1,0 +1,12 @@
+variable "count" {}
+
+variable "zones" {
+  type = "list"
+}
+
+variable "env_name" {}
+variable "network_name" {}
+
+variable "dns_zone_dns_name" {}
+
+variable "dns_zone_name" {}

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,12 @@ variable "create_gcs_buckets" {
   description = "create Google Storage Buckets for Elastic Runtime Cloud Controller's file storage"
   default     = true
 }
+
+/*****************************
+ * PKS Options *
+ *****************************/
+
+variable "pks" {
+  description = "create the required infrastructure to deploy pks"
+  default     = false
+}


### PR DESCRIPTION
Create infrastructure for PKS if enabled with `pks = true`
- creates load balancer for pks-api
- allow direct access to master nodes on port 8443
- DNS entry for *.pks.{env_name}.{dns_suffix}