### PR TITLE
Remove trailing period from opsman dns outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,11 @@ output "service_account_email" {
 }
 
 output "ops_manager_dns" {
-  value = "${google_dns_record_set.ops-manager-dns.name}"
+  value = "${replace(google_dns_record_set.ops-manager-dns.name, "/\\.$/", "")}"
 }
 
 output "optional_ops_manager_dns" {
-  value = "${element(concat(google_dns_record_set.optional-ops-manager-dns.*.name, list("")), 0)}"
+  value = "${replace(element(concat(google_dns_record_set.optional-ops-manager-dns.*.name, list("")), 0), "/\\.$/", "")}"
 }
 
 output "sys_domain" {


### PR DESCRIPTION
The current implementation for the outputs of the opsman DNS entries leaves a trailing period. We have included a call to `replace` to remove that trailing period from the output value.

We tested this manually by standing up an environment with both the regular and optional opsman VMs.