### PR TITLE
Add support for optionally creating iam service account members.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ SERVICE_ACCOUNT_KEY
 - ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
 - ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
 - opsman_storage_bucket_count: *(optional)* Google Storage Bucket for BOSH's Blobstore.
+- create_iam_service_account_members: *(optional)* Create IAM Service Account project roles. Default to false.
 
 ## DNS Records
 - pcf.*$env_name*.*$dns_suffix*: Points at the Ops Manager VM's public IP address.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ SERVICE_ACCOUNT_KEY
 - ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
 - ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
 - opsman_storage_bucket_count: *(optional)* Google Storage Bucket for BOSH's Blobstore.
-- create_iam_service_account_members: *(optional)* Create IAM Service Account project roles. Default to false.
+- create_iam_service_account_members: *(optional)* Create IAM Service Account project roles. Default to true.
 
 ## DNS Records
 - pcf.*$env_name*.*$dns_suffix*: Points at the Ops Manager VM's public IP address.

--- a/iam.tf
+++ b/iam.tf
@@ -4,30 +4,35 @@ resource "google_service_account" "opsman_service_account" {
 }
 
 resource "google_project_iam_member" "opsman_iam_service_account_actor" {
+  count = "${var.create_iam_service_account_members}"
   project = "${var.project}"
   role    = "roles/iam.serviceAccountActor"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}",
 }
 
 resource "google_project_iam_member" "opsman_compute_instance_admin" {
+  count = "${var.create_iam_service_account_members}"
   project = "${var.project}"
   role    = "roles/compute.instanceAdmin"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}",
 }
 
 resource "google_project_iam_member" "opsman_compute_network_admin" {
+  count = "${var.create_iam_service_account_members}"
   project = "${var.project}"
   role    = "roles/compute.networkAdmin"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}",
 }
 
 resource "google_project_iam_member" "opsman_compute_storage_admin" {
+  count = "${var.create_iam_service_account_members}"
   project = "${var.project}"
   role    = "roles/compute.storageAdmin"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}",
 }
 
 resource "google_project_iam_member" "opsman_storage_admin" {
+  count = "${var.create_iam_service_account_members}"
   project = "${var.project}"
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}",

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "ssl_ca_private_key" {
   default     = ""
 }
 
+variable "create_iam_service_account_members" {
+  description = "If set to true, create an IAM Service Account project roles"
+  default     = true
+}
+
 /******************
  * OpsMan Options *
  ******************/


### PR DESCRIPTION
To disable the creation of the google project iam service account
members, users can provide the following in terraform.tfvars:

  `create_iam_service_account_members = false`

This commit fixes #39