### PR TITLE
Fixing opsman_image_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ project          = "your-gcp-project"
 region           = "us-central1"
 zones            = ["us-central1-a", "us-central1-b", "us-central1-c"]
 dns_suffix       = "gcp.some-project.cf-app.com"
-opsman_image_url = "https://storage.googleapis.com/ops-manager-us/pcf-gcp-1.12.0.tar.gz"
+opsman_image_url = "https://storage.googleapis.com/ops-manager-us/pcf-gcp-2.0-build.255.tar.gz"
 
 buckets_location = "US"
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ project          = "your-gcp-project"
 region           = "us-central1"
 zones            = ["us-central1-a", "us-central1-b", "us-central1-c"]
 dns_suffix       = "gcp.some-project.cf-app.com"
-opsman_image_url = "https://storage.googleapis.com/ops-manager-us/pcf-gcp-2.0-build.255.tar.gz"
+opsman_image_url = "https://storage.googleapis.com/ops-manager-us/pcf-gcp-2.0-build.264.tar.gz"
 
 buckets_location = "US"
 


### PR DESCRIPTION
with the old version, none of the latest services from https://network.pivotal.io/ can be deployed

for example, PKS 1.0 is required OPS manager 2.0+ 