### PR TITLE
Update ops_manager.tf

### DIFF
--- a/ops_manager.tf
+++ b/ops_manager.tf
@@ -22,7 +22,7 @@ resource "google_compute_image" "ops-manager-image" {
   }
 
   raw_disk {
-    source = "${var.opsman_image_url}"
+    source = "https://storage.googleapis.com/ops-manager-${replace(var.opsman_image_url, "/.*ops-manager-(.*)/", "$1")}"
   }
 }
 


### PR DESCRIPTION
This prefixes the image with the cloud storage domain if you happen to enter it exactly as it is on the PDF of opsman images