### PR TITLE
Minor markdown README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ SERVICE_ACCOUNT_KEY
 ```
 
 ### Var Details
-- env_name: **(required)** An arbitrary unique name for namespacing resources. Max 23 characters.
+- env\_name: **(required)** An arbitrary unique name for namespacing resources. Max 23 characters.
 - project: **(required)** ID for your GCP project.
 - region: **(required)** Region in which to create resources (e.g. us-central1)
 - zones: **(required)** Zones in which to create resources. Must be within the given region. Currently you must specify exactly 3 Zones for this terraform configuration to work. (e.g. [us-central1-a, us-central1-b, us-central1-c])
-- opsman_image_url **(required)** Source URL of the Ops Manager image you want to boot.
-- service_account_key: **(required)** Contents of your service account key file generated using the `gcloud iam service-accounts keys create` command.
-- dns_suffix: **(required)** Domain to add environment subdomain to (e.g. foo.example.com)
-- buckets_location: **(optional)** Loction in which to create buckets. Defaults to US.
-- ssl_cert: **(optional)** SSL certificate for HTTP load balancer configuration. Required unless `ssl_ca_cert` is specified.
-- ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `ssl_ca_cert` is specified.
-- ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
-- ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
-- opsman_storage_bucket_count: *(optional)* Google Storage Bucket for BOSH's Blobstore.
-- create_iam_service_account_members: *(optional)* Create IAM Service Account project roles. Default to true.
+- opsman\_image\_url **(required)** Source URL of the Ops Manager image you want to boot.
+- service\_account\_key: **(required)** Contents of your service account key file generated using the `gcloud iam service-accounts keys create` command.
+- dns\_suffix: **(required)** Domain to add environment subdomain to (e.g. foo.example.com)
+- buckets\_location: **(optional)** Loction in which to create buckets. Defaults to US.
+- ssl\_cert: **(optional)** SSL certificate for HTTP load balancer configuration. Required unless `ssl_ca_cert` is specified.
+- ssl\_private\_key: **(optional)** Private key for above SSL certificate. Required unless `ssl_ca_cert` is specified.
+- ssl\_ca\_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
+- ssl\_ca\_private\_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
+- opsman\_storage\_bucket\_count: **(optional)** Google Storage Bucket for BOSH's Blobstore.
+- create\_iam\_service\_account\_members: **(optional)** Create IAM Service Account project roles. Default to true.
 
 ## DNS Records
 - pcf.*$env_name*.*$dns_suffix*: Points at the Ops Manager VM's public IP address.
@@ -114,23 +114,23 @@ SERVICE_ACCOUNT_KEY
 - tcp.*$env_name*.*$dns_suffix*: Points at the TCP load balancer in front of the TCP router.
 
 ## Isolation Segments (optional)
-- isolation_segment: **(optional)** When set to "true" creates HTTP load-balancer across 3 zones for isolation segments.
-- iso_seg_ssl_cert: **(optional)** SSL certificate for Iso Seg HTTP load balancer configuration. Required unless `iso_seg_ssl_ca_cert` is specified.
-- iso_seg_ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `iso_seg_ssl_ca_cert` is specified.
-- iso_seg_ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed Iso Seg HTTP load balancer certificate. Required unless `iso_seg_ssl_cert` is specified.
-- iso_seg_ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `iso_seg_ssl_cert` is specified.
+- isolation\_segment: **(optional)** When set to "true" creates HTTP load-balancer across 3 zones for isolation segments.
+- iso\_seg\_ssl\_cert: **(optional)** SSL certificate for Iso Seg HTTP load balancer configuration. Required unless `iso_seg_ssl_ca_cert` is specified.
+- iso\_seg\_ssl\_private\_key: **(optional)** Private key for above SSL certificate. Required unless `iso_seg_ssl_ca_cert` is specified.
+- iso\_seg\_ssl\_ca\_cert: **(optional)** SSL CA certificate used to generate self-signed Iso Seg HTTP load balancer certificate. Required unless `iso_seg_ssl_cert` is specified.
+- iso\_seg\_ssl\_ca\_private\_key: **(optional)** Private key for above SSL CA certificate. Required unless `iso_seg_ssl_cert` is specified.
 
 ## Cloud SQL Configuration (optional)
-- external_database: *(optional)* When set to "true", a cloud SQL instance will be deployed for the Ops Manager and PAS.
+- external\_database: **(optional)** When set to "true", a cloud SQL instance will be deployed for the Ops Manager and PAS.
 
-#### Ops Manager
-- opsman_sql_db_host: *(optional)* The host the user can connect from. Can be an IP address. Changing this forces a new resource to be created.
+## Ops Manager (optional)
+- opsman\_sql\_db\_host: **(optional)** The host the user can connect from. Can be an IP address. Changing this forces a new resource to be created.
 
-#### PAS
-- pas_sql_db_host: *(optional)* The host the user can connect from. Can be an IP address. Changing this forces a new resource to be created.
+## PAS (optional)
+- pas\_sql\_db\_host: **(optional)** The host the user can connect from. Can be an IP address. Changing this forces a new resource to be created.
 
 ## PAS Cloud Controller's Google Cloud Storage Buckets (optional)
-- create_gcs_buckets: *(optional)* When set to "false", buckets will not be created for PAS Cloud Controller. Defaults to "true".
+- create\_gcs\_buckets: **(optional)** When set to "false", buckets will not be created for PAS Cloud Controller. Defaults to "true".
 
 ## PKS (optional)
 - pks: **(optional)** When set to "true" creates a tcp load-balancer for PKS api, dedicated subnets and allows access on Port `8443` to `masters` external IP address for `kubectl` access


### PR DESCRIPTION
* Fix missing double "*" sequences in a few "optional" sections.
* Escape underscore ("_") for proper rendering in "MacDown" (The open
  source Markdown editor for macOS)
* Fix heading for "Ops Manager" and "PAS" sections.