### PR TITLE
Update dns records to resolve to haproxy ip instead of external ips.

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -25,6 +25,11 @@ resource "google_dns_record_set" "optional-ops-manager-dns" {
   rrdatas = ["${google_compute_instance.optional-ops-manager.network_interface.0.access_config.0.assigned_nat_ip}"]
 }
 
+// Modify dns records to resolve to the ha proxy when in internetless mode.
+locals {
+  haproxy_static_ip = "${cidrhost(google_compute_subnetwork.pas-subnet.ip_cidr_range, -20)}"
+}
+
 resource "google_dns_record_set" "wildcard-sys-dns" {
   name = "*.sys.${google_dns_managed_zone.env_dns_zone.dns_name}"
   type = "A"
@@ -32,7 +37,7 @@ resource "google_dns_record_set" "wildcard-sys-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_global_address.cf.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_global_address.cf.address}"]
 }
 
 resource "google_dns_record_set" "doppler-sys-dns" {
@@ -42,7 +47,7 @@ resource "google_dns_record_set" "doppler-sys-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_address.cf-ws.address}"]
 }
 
 resource "google_dns_record_set" "loggregator-sys-dns" {
@@ -52,7 +57,7 @@ resource "google_dns_record_set" "loggregator-sys-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_address.cf-ws.address}"]
 }
 
 resource "google_dns_record_set" "wildcard-apps-dns" {
@@ -62,7 +67,7 @@ resource "google_dns_record_set" "wildcard-apps-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_global_address.cf.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_global_address.cf.address}"]
 }
 
 resource "google_dns_record_set" "wildcard-ws-dns" {
@@ -72,7 +77,7 @@ resource "google_dns_record_set" "wildcard-ws-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_address.cf-ws.address}"]
 }
 
 resource "google_dns_record_set" "app-ssh-dns" {
@@ -82,7 +87,7 @@ resource "google_dns_record_set" "app-ssh-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_address.cf-ssh.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_address.cf-ssh.address}"]
 }
 
 resource "google_dns_record_set" "tcp-dns" {
@@ -92,5 +97,5 @@ resource "google_dns_record_set" "tcp-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_address.cf-tcp.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_address.cf-tcp.address}"]
 }

--- a/internetless.tf
+++ b/internetless.tf
@@ -1,4 +1,4 @@
-// Allow open access between internal VMs for a PCF deployment
+// Allow ingress between internal VMs for a PCF deployment
 resource "google_compute_firewall" "cf-internal-ingress" {
   count = "${var.internetless ? 1 : 0}"
 
@@ -28,6 +28,7 @@ resource "google_compute_firewall" "cf-internal-ingress" {
   ]
 }
 
+// Allow egress between internal VMs for a PCF deployment
 resource "google_compute_firewall" "cf-internal-egress" {
   count = "${var.internetless ? 1 : 0}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,10 @@ output "optional_ops_manager_dns" {
   value = "${replace(element(concat(google_dns_record_set.optional-ops-manager-dns.*.name, list("")), 0), "/\\.$/", "")}"
 }
 
+output "haproxy_static_ip" {
+  value = "${local.haproxy_static_ip}"
+}
+
 output "sys_domain" {
   value = "${replace(replace(google_dns_record_set.wildcard-sys-dns.name, "/^\\*\\./", ""), "/\\.$/", "")}"
 }


### PR DESCRIPTION
- Add haproxy static ip output for ert product configuration.

[#157561315] Replace vsphere internetless envs with internetless envs on a public IaaS

This is because when we standup an internetless environment, in order for PAS to deploy and run errands successfully, we need to use a HAProxy VM (with a internal IP address) instead of the load balancer (created with external IP addresses).

Signed-off-by: Caitlyn Yu <cyu@pivotal.io>