### PR TITLE
use resource name for IP address on DNS entry

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -11,7 +11,7 @@ resource "google_dns_record_set" "ops-manager-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_instance.ops-manager.network_interface.0.access_config.0.assigned_nat_ip}"]
+  rrdatas = ["${google_compute_address.ops-manager-ip.address}"]
 }
 
 resource "google_dns_record_set" "optional-ops-manager-dns" {
@@ -22,7 +22,7 @@ resource "google_dns_record_set" "optional-ops-manager-dns" {
 
   managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
 
-  rrdatas = ["${google_compute_instance.optional-ops-manager.network_interface.0.access_config.0.assigned_nat_ip}"]
+  rrdatas = ["${google_compute_address.optional-ops-manager-ip.address}"]
 }
 
 // Modify dns records to resolve to the ha proxy when in internetless mode.


### PR DESCRIPTION
The IP address for the OpsManager DNS entry was being determine via the NAT IP address assigned to the VM. This worked™, but caused a strange dependency graph.

The DNS entry depends on the IP address resource now.

This is the first pass at creating the infrastructure only terraform. With the next step being the OpsMan VM being optional, but have all the required ref-arch supported.