### PR TITLE
Add Output support for the CloudSQL Server Certificate.

### DIFF
--- a/external_database/outputs.tf
+++ b/external_database/outputs.tf
@@ -20,6 +20,11 @@ output "pas_sql_password" {
   value     = "${element(concat(random_id.pas_db_password.*.b64, list("")), 0)}"
 }
 
+output "pas_sql_cert" {
+  sensitive = true
+  value     = "${google_sql_database_instance.master.server_ca_cert.0.cert}"
+}
+
 output "ip" {
   value = "${element(concat(google_sql_database_instance.master.*.first_ip_address, list("")), 0)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -216,6 +216,11 @@ output "pas_sql_password" {
   value     = "${module.external_database.pas_sql_password}"
 }
 
+output "pas_sql_cert" {
+  sensitive = true
+  value     = "${module.external_database.pas_sql_cert}"
+}
+
 output "opsman_sql_username" {
   value = "${module.external_database.opsman_sql_username}"
 }


### PR DESCRIPTION
Added Terraform Output support for the CloudSQL instance's Server CA certificate. Users will need this to create an encrypted connection with the Cloud SQL Instance.

This is the cert needed down the road in a PAS installation of CredHub that has a mandatory Server-CA field.

An example Encrypted connection can be obtained with the below script after:

```
#!/bin/sh

export HOST=`terraform output sql_db_ip`
export USER=`terraform output opsman_sql_username`
export PASS=`terraform output opsman_sql_password`

echo "PAS SQL Password: $PASS"

terraform output pas_sql_cert > server-ca.pem

echo "Encrypted Connection String:"

echo "mysql -u $USER -h $HOST -p \ "
echo     "--ssl-ca=server-ca.pem"

exit 0
```