### PR TITLE
fix: DB cert error when external DB is set to false

### DIFF
--- a/external_database/outputs.tf
+++ b/external_database/outputs.tf
@@ -22,7 +22,7 @@ output "pas_sql_password" {
 
 output "pas_sql_cert" {
   sensitive = true
-  value     = "${google_sql_database_instance.master.server_ca_cert.0.cert}"
+  value     = "${element(concat(google_sql_database_instance.master.*.server_ca_cert.0.cert, list("")), 0)}"
 }
 
 output "ip" {


### PR DESCRIPTION
A user reported that they received an error due to the db-ca-cert when they were not using an external DB:
https://github.com/pivotal-cf/terraforming-gcp/commit/aa6363b5689a1c7628562cd15b9c90a2f4c89a1f#commitcomment-30012490

This PR is to fix this bug/error when not using an external DB.

Both with and without an external DB work fine now with this commit.