### PR TITLE
Iso Seg module now respects 'internetless' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ SERVICE_ACCOUNT_KEY
 - pks: **(optional)** When set to "true" creates a tcp load-balancer for PKS api, dedicated subnets and allows access on Port `8443` to `masters` external IP address for `kubectl` access
 
 ## Internetless (optional)
-- internetless: **(optional)** When set to "true", all traffic going outside the 10.* network is denied.
+- internetless: **(optional)** When set to "true", all traffic going outside the 10.* network is denied. DNS records like '*.apps.DOMAIN' will be pointed to the HAProxy static IP rather than the LB address.
 
 ## Running
 

--- a/isolation_segment/dns.tf
+++ b/isolation_segment/dns.tf
@@ -1,3 +1,7 @@
+locals {
+  haproxy_static_ip = "${cidrhost(var.pas_subnet_cidr, -19)}"
+}
+
 resource "google_dns_record_set" "wildcard-iso-dns" {
   name  = "*.iso.${var.dns_zone_dns_name}."
   type  = "A"
@@ -6,5 +10,5 @@ resource "google_dns_record_set" "wildcard-iso-dns" {
 
   managed_zone = "${var.dns_zone_name}"
 
-  rrdatas = ["${google_compute_global_address.isoseg.address}"]
+  rrdatas = ["${var.internetless ? local.haproxy_static_ip : google_compute_global_address.isoseg.address}"]
 }

--- a/isolation_segment/outputs.tf
+++ b/isolation_segment/outputs.tf
@@ -15,3 +15,7 @@ output "ssl_private_key" {
 output "domain" {
   value = "${replace(replace(element(concat(google_dns_record_set.wildcard-iso-dns.*.name, list("")), 0), "/^\\*\\./", ""), "/\\.$/", "")}"
 }
+
+output "haproxy_static_ip" {
+  value = "${local.haproxy_static_ip}"
+}

--- a/isolation_segment/variables.tf
+++ b/isolation_segment/variables.tf
@@ -19,3 +19,7 @@ variable "dns_zone_dns_name" {}
 variable "dns_zone_name" {}
 
 variable "public_healthcheck_link" {}
+
+variable "pas_subnet_cidr" {}
+
+variable "internetless" {}

--- a/modules.tf
+++ b/modules.tf
@@ -28,6 +28,9 @@ module "isolation_segment" {
   dns_zone_name           = "${google_dns_managed_zone.env_dns_zone.name}"
   dns_zone_dns_name       = "${var.env_name}.${var.dns_suffix}"
   public_healthcheck_link = "${google_compute_http_health_check.cf-public.self_link}"
+
+  pas_subnet_cidr = "${google_compute_subnetwork.pas-subnet.ip_cidr_range}"
+  internetless    = "${var.internetless}"
 }
 
 module "pks" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -171,6 +171,10 @@ output "iso_seg_ssl_private_key" {
   value     = "${module.isolation_segment.ssl_private_key}"
 }
 
+output "iso_seg_haproxy_static_ip" {
+  value = "${module.isolation_segment.haproxy_static_ip}"
+}
+
 output "ws_router_pool" {
   value = "${element(concat(google_compute_target_pool.cf-ws.*.name, list("")), 0)}"
 }


### PR DESCRIPTION
- Adds 'iso_seg_haproxy_static_ip' output

[#160404989]

Signed-off-by: Joseph Palermo <jpalermo@pivotal.io>