### PR TITLE
Add missing required API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You will need to enable the following Google Cloud APIs:
 - [Cloud Resource Manager](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/)
 - [Cloud DNS](https://console.developers.google.com/apis/api/dns/overview)
 - [Cloud SQL API](https://console.developers.google.com/apis/api/sqladmin/overview)
+- [Compute Engine API](https://console.developers.google.com/apis/library/compute.googleapis.com)
 
 ### Var File
 


### PR DESCRIPTION
Without this the following error occurs:

* google_compute_instance_group.httplb[1]: Error reading InstanceGroup Members: googleapi: Error 403: Access Not Configured. Compute Engine API has not been used in project...