### PR TITLE
Add storage.objectViewer perms to worker service account

### DIFF
--- a/modules/pks/iam.tf
+++ b/modules/pks/iam.tf
@@ -51,3 +51,9 @@ resource "google_project_iam_member" "pks_worker_node_compute_viewer" {
   role    = "roles/compute.viewer"
   member  = "serviceAccount:${google_service_account.pks_worker_node_service_account.email}"
 }
+
+resource "google_project_iam_member" "pks_worker_node_compute_viewer" {
+  project = "${var.project}"
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.pks_worker_node_service_account.email}"
+}

--- a/modules/pks/iam.tf
+++ b/modules/pks/iam.tf
@@ -52,7 +52,7 @@ resource "google_project_iam_member" "pks_worker_node_compute_viewer" {
   member  = "serviceAccount:${google_service_account.pks_worker_node_service_account.email}"
 }
 
-resource "google_project_iam_member" "pks_worker_node_compute_viewer" {
+resource "google_project_iam_member" "pks_worker_node_storage_object_viewer" {
   project = "${var.project}"
   role    = "roles/storage.objectViewer"
   member  = "serviceAccount:${google_service_account.pks_worker_node_service_account.email}"


### PR DESCRIPTION
In our environment pks workers can not access container images in `gcr.io` registry without this perm. 

Co-authored-by: Jemish Patel <jpatel@pivotal.io>
Co-authored-by: Goutam Tadi <gtadi@pivotal.io>