### PR TITLE
Add firewall rules to locked down Isolation Segment

### DIFF
--- a/modules/isolation_segment/firewalls.tf
+++ b/modules/isolation_segment/firewalls.tf
@@ -1,5 +1,5 @@
 resource "google_compute_firewall" "isoseg-cf-internal" {
-  count = "${var.count}"
+  count = "${var.count * var.with_firewalls}"
 
   name     = "${var.env_name}-isoseg-cf-internal"
   network  = "${var.network}"
@@ -22,7 +22,7 @@ resource "google_compute_firewall" "isoseg-cf-internal" {
 }
 
 resource "google_compute_firewall" "isoseg-cf-ingress" {
-  count = "${var.count}"
+  count = "${var.count * var.with_firewalls}"
 
   name    = "${var.env_name}-isoseg-cf-ingress"
   network = "${var.network}"
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "isoseg-cf-ingress" {
 }
 
 resource "google_compute_firewall" "isoseg-block-cf-ingress" {
-  count = "${var.count}"
+  count = "${var.count * var.with_firewalls}"
 
   name    = "${var.env_name}-isoseg-block-cf-ingress"
   network = "${var.network}"
@@ -62,7 +62,7 @@ resource "google_compute_firewall" "isoseg-block-cf-ingress" {
 }
 
 resource "google_compute_firewall" "cf-isoseg-ingress" {
-  count = "${var.count}"
+  count = "${var.count * var.with_firewalls}"
 
   name    = "${var.env_name}-cf-isoseg-ingress"
   network = "${var.network}"

--- a/modules/isolation_segment/variables.tf
+++ b/modules/isolation_segment/variables.tf
@@ -1,5 +1,7 @@
 variable "count" {}
 
+variable "with_firewalls" {}
+
 variable "zones" {
   type = "list"
 }

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -105,12 +105,13 @@ module "isoseg_certs" {
 module "isolation_segment" {
   source = "../modules/isolation_segment"
 
-  count = "${var.isolation_segment ? 1 : 0}"
+  count = "${var.isolation_segment}"
 
   env_name          = "${var.env_name}"
   zones             = "${var.zones}"
   internetless      = "${var.internetless}"
   dns_zone_dns_name = "${var.env_name}.${var.dns_suffix}"
+  with_firewalls    = "${var.iso_seg_with_firewalls}"
 
   network                  = "${module.infra.network}"
   dns_zone_name            = "${module.infra.dns_zone_name}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -137,6 +137,11 @@ variable "isolation_segment" {
   default     = false
 }
 
+variable "iso_seg_with_firewalls" {
+  description = "create firewalls to lock down ports on the isolation segment"
+  default     = false
+}
+
 variable "iso_seg_ssl_cert" {
   type        = "string"
   description = "the contents of an SSL certificate to be used by the LB, optional if `iso_seg_ssl_ca_cert` is provided"


### PR DESCRIPTION
Open up/lock down ports according to the documentation: https://docs.pivotal.io/pivotalcf/2-3/adminguide/routing-is.html#config-firewall

[161933469] Harden terraforming-gcp for PAS Isolation Segments

cc @evanfarrar @genevieve 