### PR TITLE
Limit firewall ports between Director and IST VMs

### DIFF
--- a/modules/isolation_segment/firewalls.tf
+++ b/modules/isolation_segment/firewalls.tf
@@ -1,3 +1,4 @@
+/* This firewall allows traffic between VMs in the isolation segment. */
 resource "google_compute_firewall" "isoseg-cf-internal" {
   count = "${var.count * var.with_firewalls}"
 
@@ -21,6 +22,7 @@ resource "google_compute_firewall" "isoseg-cf-internal" {
   target_tags = ["isoseg-${var.env_name}"]
 }
 
+/* This firewall allows traffic on certain ports from cf to the isolation segment. */
 resource "google_compute_firewall" "isoseg-cf-ingress" {
   count = "${var.count * var.with_firewalls}"
 
@@ -37,6 +39,7 @@ resource "google_compute_firewall" "isoseg-cf-ingress" {
   }
 }
 
+/* This firewall denies traffic from cf to the isolation segment on all ports. */
 resource "google_compute_firewall" "isoseg-block-cf-ingress" {
   count = "${var.count * var.with_firewalls}"
 
@@ -61,6 +64,7 @@ resource "google_compute_firewall" "isoseg-block-cf-ingress" {
   }
 }
 
+/* This firewall allows traffic on certain ports from the isolation segment to cf. */
 resource "google_compute_firewall" "cf-isoseg-ingress" {
   count = "${var.count * var.with_firewalls}"
 
@@ -105,6 +109,7 @@ resource "google_compute_firewall" "cf-isoseg-ingress" {
   }
 }
 
+/* This firewall denies traffic from the isolation segment to cf on all ports. */
 resource "google_compute_firewall" "cf-block-isoseg-ingress" {
   count = "${var.count}"
 
@@ -114,6 +119,102 @@ resource "google_compute_firewall" "cf-block-isoseg-ingress" {
   source_tags = ["isoseg-${var.env_name}"]
   target_tags = ["cf-${var.env_name}"]
   priority    = 999
+
+  deny {
+    protocol = "icmp"
+  }
+
+  deny {
+    protocol = "tcp"
+  }
+
+  deny {
+    protocol = "udp"
+  }
+}
+
+/* This firewall allows ssh from the bosh director to the PAS subnet. */
+resource "google_compute_firewall" "bosh-to-isoseg-allow" {
+  count = "${var.count * var.with_firewalls}"
+
+  name    = "${var.env_name}-bosh-to-isoseg-allow"
+  network = "${var.network}"
+
+  direction = "INGRESS"
+
+  source_ranges = ["${var.infrastructure_subnet_cidr}"]
+  target_tags   = ["isoseg-${var.env_name}"]
+  priority      = 998
+
+  allow {
+    protocol = "tcp"
+
+    ports = [
+      "22",
+    ]
+  }
+}
+
+resource "google_compute_firewall" "bosh-to-isoseg-deny" {
+  count = "${var.count * var.with_firewalls}"
+
+  name    = "${var.env_name}-bosh-to-isoseg-deny"
+  network = "${var.network}"
+
+  direction = "INGRESS"
+
+  source_ranges = ["${var.infrastructure_subnet_cidr}"]
+  target_tags   = ["isoseg-${var.env_name}"]
+  priority      = 999
+
+  deny {
+    protocol = "icmp"
+  }
+
+  deny {
+    protocol = "tcp"
+  }
+
+  deny {
+    protocol = "udp"
+  }
+}
+
+/* This firewall allows some ports from PAS subnet to bosh director. */
+resource "google_compute_firewall" "isoseg-to-bosh-allow" {
+  count = "${var.count * var.with_firewalls}"
+
+  name    = "${var.env_name}-isoseg-to-bosh-allow"
+  network = "${var.network}"
+
+  direction = "EGRESS"
+
+  target_tags        = ["isoseg-${var.env_name}"]
+  destination_ranges = ["${var.infrastructure_subnet_cidr}"]
+  priority           = 998
+
+  allow {
+    protocol = "tcp"
+
+    ports = [
+      "4222",
+      "25250",
+      "25777",
+    ]
+  }
+}
+
+resource "google_compute_firewall" "isoseg-to-bosh-deny" {
+  count = "${var.count * var.with_firewalls}"
+
+  name    = "${var.env_name}-isoseg-to-bosh-deny"
+  network = "${var.network}"
+
+  direction = "EGRESS"
+
+  target_tags        = ["isoseg-${var.env_name}"]
+  destination_ranges = ["${var.infrastructure_subnet_cidr}"]
+  priority           = 999
 
   deny {
     protocol = "icmp"

--- a/modules/isolation_segment/variables.tf
+++ b/modules/isolation_segment/variables.tf
@@ -14,6 +14,8 @@ variable "dns_zone_name" {}
 
 variable "public_health_check_link" {}
 
+variable "infrastructure_subnet_cidr" {}
+
 variable "pas_subnet_cidr" {}
 
 variable "network" {}

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -113,11 +113,12 @@ module "isolation_segment" {
   dns_zone_dns_name = "${var.env_name}.${var.dns_suffix}"
   with_firewalls    = "${var.iso_seg_with_firewalls}"
 
-  network                  = "${module.infra.network}"
-  dns_zone_name            = "${module.infra.dns_zone_name}"
-  public_health_check_link = "${module.pas.cf_public_health_check}"
-  pas_subnet_cidr          = "${module.pas.pas_subnet_ip_cidr_range}"
-  ssl_certificate          = "${module.isoseg_certs.ssl_certificate}"
+  network                    = "${module.infra.network}"
+  dns_zone_name              = "${module.infra.dns_zone_name}"
+  public_health_check_link   = "${module.pas.cf_public_health_check}"
+  infrastructure_subnet_cidr = "${var.infrastructure_cidr}"
+  pas_subnet_cidr            = "${module.pas.pas_subnet_ip_cidr_range}"
+  ssl_certificate            = "${module.isoseg_certs.ssl_certificate}"
 }
 
 module "external_database" {


### PR DESCRIPTION
This PR further limits the set of allowed ports between the BOSH director and the IST VMs. Traffic on ports like NATs is allowed but all other traffic between the IST VMs and the `infrastructure` subnet is denied.

We also added comments to our previous firewall rules to indicate why the rule is necessary and a big warning to remember to update docs if you have to change any of the firewall rules.