### PR TITLE
Simplify iso seg firewall implementation

### DIFF
--- a/modules/isolation_segment/variables.tf
+++ b/modules/isolation_segment/variables.tf
@@ -23,3 +23,5 @@ variable "network" {}
 variable "internetless" {}
 
 variable "ssl_certificate" {}
+
+variable "replicated_suffix" {}

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -120,6 +120,7 @@ module "isolation_segment" {
   infrastructure_subnet_cidr = "${var.infrastructure_cidr}"
   pas_subnet_cidr            = "${module.pas.pas_subnet_ip_cidr_range}"
   ssl_certificate            = "${module.isoseg_certs.ssl_certificate}"
+  replicated_suffix          = "${var.iso_seg_replicated_suffix}"
 }
 
 module "external_database" {

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -170,6 +170,12 @@ variable "iso_seg_ssl_ca_private_key" {
   default     = ""
 }
 
+variable "iso_seg_replicated_suffix" {
+  type        = "string"
+  description = "If you are using the tile `replicator` CLI, set this variable to match the replicated suffix. Will be used to set networking firewall rules."
+  default     = "-replicated"
+}
+
 /*********************************
  * Google Cloud Storage Options *
  *********************************/


### PR DESCRIPTION
- Rather than needing to apply custom network tags to every VM using
  vm_extensions, the rules now use the VM names as tags as BOSH
  automatically applies the VM name as a tag to each VM

[#162348396]