### PR TITLE
Add control plane output for director blobstore service account key

### DIFF
--- a/terraforming-control-plane/outputs.tf
+++ b/terraforming-control-plane/outputs.tf
@@ -39,6 +39,11 @@ output "director_blobstore_bucket" {
   value = "${module.ops_manager.director_blobstore_bucket}"
 }
 
+output "director_blobstore_service_account_key" {
+  value = "${module.infra.blobstore_gcp_service_account_key}"
+  sensitive = true
+}
+
 output "infrastructure_subnet_gateway" {
   value = "${module.infra.subnet_gateway}"
 }


### PR DESCRIPTION
This PR adds the terraform output for the director's blobstore service account key, under the terraforming-control-plane directory.

The service account key is already created under the [modules/infra/output](https://github.com/pivotal-cf/terraforming-gcp/blob/master/modules/infra/outputs.tf#L37-L40) terraform.

This PR will just Expose it to terraforming control plane with the below when the `opsman_storage_bucket_count = 1` variable has been added to the `terraform.tfvars` file:

`terraform output director_blobstore_service_account_key`

and the below to get the one line string variation for Automation

`terraform output director_blobstore_service_account_key | jq 'tostring'`

Usage:
```
export DIR_SERVICE_ACCOUNT_KEY=`terraform output director_blobstore_service_account_key | jq 'tostring'`
export DIR_GCS_BUCKET=`terraform output director_blobstore_bucket`
export BLOBSTORE_JSON="blobstore_config.json"

cat > $BLOBSTORE_JSON <<EOL
{
  "blobstore_type": "gcs",
  "gcs_blobstore_options": {
      "bucket_name": "${DIR_GCS_BUCKET}",
      "storage_class": "MULTI_REGIONAL",
      "service_account_key": ${DIR_SERVICE_ACCOUNT_KEY}
  }
}
EOL

om configure-director --director-configuration "$(cat $BLOBSTORE_JSON)"
```

This was also tested to display as blank when the optional `opsman_storage_bucket_count = 1` variable has been Not been added to the `terraform.tfvars` file.