### PR TITLE
make ops-manager-image optional

### DIFF
--- a/modules/ops_manager/image.tf
+++ b/modules/ops_manager/image.tf
@@ -1,6 +1,7 @@
 resource "google_compute_image" "ops-manager-image" {
   name = "${var.env_name}-ops-manager-image"
-
+  count = "${min(length(split("", var.opsman_image_url)),1)}"
+  
   timeouts {
     create = "20m"
   }


### PR DESCRIPTION
`p-automator` does handle the image upload, hence making it optional is helpful.
This change doesn't break existing configurations, as specifying the opsman URL is mandatory.
Only setting `opsman_image_url=""` will *not* upload the image.
`opsman_vm` is already optional.