### PR TITLE
Update assigned_nat_ip to nat_ip in accordance with new GCP API

### DIFF
--- a/modules/jumpbox/dns.tf
+++ b/modules/jumpbox/dns.tf
@@ -6,5 +6,5 @@ resource "google_dns_record_set" "jumpbox-dns" {
   ttl  = 300
 
   managed_zone = "${var.pcf_managed_zone_name}"
-  rrdatas      = ["${google_compute_instance.jumpbox.network_interface.0.access_config.0.assigned_nat_ip}"]
+  rrdatas      = ["${google_compute_instance.jumpbox.network_interface.0.access_config.0.nat_ip}"]
 }


### PR DESCRIPTION
* Using `assigned_nat_ip` in `google_dns_record_set` won't error, but it will resolve to an empty string
* Terraform docs also indicate this is the correct way to reference this field: https://www.terraform.io/docs/providers/google/d/datasource_compute_instance.html#network_interface-0-access_config-0-nat_ip

[[#164011470](https://www.pivotaltracker.com/story/show/164011470)]

Signed-off-by: Denise Yu <dyu@pivotal.io>