### PR TITLE
update iam roles to align with pks documents service account roles

### DIFF
--- a/modules/ops_manager/iam.tf
+++ b/modules/ops_manager/iam.tf
@@ -7,17 +7,24 @@ resource "google_service_account_key" "opsman_service_account_key" {
   service_account_id = "${google_service_account.opsman_service_account.id}"
 }
 
-resource "google_project_iam_member" "opsman_iam_service_account_actor" {
+resource "google_project_iam_member" "opsman_iam_service_account_user" {
   count   = "${var.create_iam_service_account_members}"
   project = "${var.project}"
-  role    = "roles/iam.serviceAccountActor"
+  role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}"
 }
 
-resource "google_project_iam_member" "opsman_compute_instance_admin" {
+resource "google_project_iam_member" "opsman_iam_service_account_token_creator" {
   count   = "${var.create_iam_service_account_members}"
   project = "${var.project}"
-  role    = "roles/compute.instanceAdmin"
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.opsman_service_account.email}"
+}
+
+resource "google_project_iam_member" "opsman_compute_instance_admin_v1" {
+  count   = "${var.create_iam_service_account_members}"
+  project = "${var.project}"
+  role    = "roles/compute.instanceAdmin.v1"
   member  = "serviceAccount:${google_service_account.opsman_service_account.email}"
 }
 

--- a/modules/pks/iam.tf
+++ b/modules/pks/iam.tf
@@ -16,9 +16,9 @@ resource "google_service_account_key" "pks_worker_node_service_account_key" {
   service_account_id = "${google_service_account.pks_worker_node_service_account.id}"
 }
 
-resource "google_project_iam_member" "pks_master_node_compute_instance_admin" {
+resource "google_project_iam_member" "pks_master_node_compute_instance_admin_v1" {
   project = "${var.project}"
-  role    = "roles/compute.instanceAdmin"
+  role    = "roles/compute.instanceAdmin.v1"
   member  = "serviceAccount:${google_service_account.pks_master_node_service_account.email}"
 }
 
@@ -40,9 +40,15 @@ resource "google_project_iam_member" "pks_master_node_compute_security_admin" {
   member  = "serviceAccount:${google_service_account.pks_master_node_service_account.email}"
 }
 
-resource "google_project_iam_member" "pks_master_node_iam_service_account_actor" {
+resource "google_project_iam_member" "pks_master_node_iam_service_account_user" {
   project = "${var.project}"
-  role    = "roles/iam.serviceAccountActor"
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.pks_master_node_service_account.email}"
+}
+
+resource "google_project_iam_member" "pks_master_node_compute_viewer" {
+  project = "${var.project}"
+  role    = "roles/compute.viewer"
   member  = "serviceAccount:${google_service_account.pks_master_node_service_account.email}"
 }
 


### PR DESCRIPTION
issue #115 

Follow the following two documentations for required roles mapping:

* Ops Manager 2.4 on GCP [document](https://docs.pivotal.io/pivotalcf/2-4/om/gcp/prepare-env-manual.html#iam_account)
* PKS 1.3 on GCP Service Account [document](https://docs.pivotal.io/runtimes/pks/1-3/gcp-service-accounts.html)

*Ops Manager Service Account*

```
ROLE
roles/compute.instanceAdmin.v1
roles/compute.networkAdmin
roles/compute.storageAdmin
roles/iam.serviceAccountTokenCreator
roles/iam.serviceAccountUser
roles/storage.admin
```

*Master Node Service Account*

```
ROLE
roles/compute.instanceAdmin.v1
roles/compute.networkAdmin
roles/compute.securityAdmin
roles/compute.storageAdmin
roles/compute.viewer
roles/iam.serviceAccountUser
```

*Worker Node Service Account*

```
ROLE
roles/compute.viewer
```