### PR TITLE
Enable Opsman & PAS to connect to cloudSQL by removing PAS DB host limitation

### DIFF
--- a/modules/pas/external_db.tf
+++ b/modules/pas/external_db.tf
@@ -134,7 +134,6 @@ resource "google_sql_user" "pas" {
   name     = "${random_id.pas_db_username.b64}"
   password = "${random_id.pas_db_password.b64}"
   instance = "${var.sql_instance}"
-  host     = "${var.pas_sql_db_host}"
 
   count = "${local.external_db_count}"
 }


### PR DESCRIPTION
Potential Resolution to issue #127 where PAS cannot connect to the cloudSQL using PAS credentials generated by terraform.

This PR removes the host limitation that is stopping Ops manager Verifier and PAS VM like ccd, uaa, etc. from connection to the cloudSQL instance.