### PR TITLE
Enable private Google API access for PAS and Services Networks

### DIFF
--- a/modules/pas/network.tf
+++ b/modules/pas/network.tf
@@ -3,6 +3,7 @@ resource "google_compute_subnetwork" "pas" {
   ip_cidr_range = "${var.pas_cidr}"
   network       = "${var.network}"
   region        = "${var.region}"
+  private_ip_google_access = true
 }
 
 resource "google_compute_subnetwork" "services" {
@@ -10,4 +11,5 @@ resource "google_compute_subnetwork" "services" {
   ip_cidr_range = "${var.services_cidr}"
   network       = "${var.network}"
   region        = "${var.region}"
+  private_ip_google_access = true
 }


### PR DESCRIPTION
Enable private Google API access for PAS and Services Networks by default.

I see no reason to not have this turned on by default. If it isn't turned on, This can cause certain On Demand Services Tile's service instances to fail for not being able to get an API token from Google.

This PR turns it on automatically to prevent issues like this from services.

Resolves Issue
#129 