### PR TITLE
Enable private Google API access for PKS and Services Networks

### DIFF
--- a/modules/pks/networks.tf
+++ b/modules/pks/networks.tf
@@ -3,6 +3,7 @@ resource "google_compute_subnetwork" "pks-subnet" {
   ip_cidr_range = "${var.pks_cidr}"
   network       = "${var.network_name}"
   region        = "${var.region}"
+  private_ip_google_access = true
 }
 
 resource "google_compute_subnetwork" "pks-services-subnet" {
@@ -10,4 +11,5 @@ resource "google_compute_subnetwork" "pks-services-subnet" {
   ip_cidr_range = "${var.pks_services_cidr}"
   network       = "${var.network_name}"
   region        = "${var.region}"
+  private_ip_google_access = true
 }


### PR DESCRIPTION
Enable private Google API access for PKS and PKS Services Networks by default.

I see no reason to not have this turned on by default. If it isn't turned on, This can cause certain issue in PKS as mentioned in the comments of issue #45 

Partially Resolves Issue
#45 in terms of PKS, but not the Director