### PR TITLE
Refactor loadbalancer

### DIFF
--- a/modules/load_balancer/global.tf
+++ b/modules/load_balancer/global.tf
@@ -1,9 +1,9 @@
 locals {
-  count = "${var.global ? 1 : 0}"
+  count = "${(var.global && var.count > 0 ) ? 1 : 0}"
 }
 
 resource "google_compute_backend_service" "http_lb_backend_service" {
-  name        = "${var.env_name}-httpslb"
+  name        = "${var.lb_name}"
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 900
@@ -29,7 +29,7 @@ resource "google_compute_backend_service" "http_lb_backend_service" {
 resource "google_compute_instance_group" "httplb" {
   // Count based on number of AZs
   count       = "${var.global > 0 ? 3 : 0}"
-  name        = "${var.env_name}-httpslb-${element(var.zones, count.index)}"
+  name        = "${var.lb_name}-${element(var.zones, count.index)}"
   description = "terraform generated instance group that is multi-zone for https loadbalancing"
   zone        = "${element(var.zones, count.index)}"
 }
@@ -41,7 +41,7 @@ resource "google_compute_global_address" "lb" {
 }
 
 resource "google_compute_url_map" "https_lb_url_map" {
-  name = "${var.env_name}-cf-http"
+  name = "${var.url_map_name}"
 
   default_service = "${google_compute_backend_service.http_lb_backend_service.self_link}"
 
@@ -49,7 +49,7 @@ resource "google_compute_url_map" "https_lb_url_map" {
 }
 
 resource "google_compute_target_http_proxy" "http_lb_proxy" {
-  name        = "${var.env_name}-httpproxy"
+  name        = "${var.http_proxy_name}"
   description = "really a load balancer but listed as an https proxy"
   url_map     = "${google_compute_url_map.https_lb_url_map.self_link}"
 
@@ -57,7 +57,7 @@ resource "google_compute_target_http_proxy" "http_lb_proxy" {
 }
 
 resource "google_compute_target_https_proxy" "https_lb_proxy" {
-  name             = "${var.env_name}-httpsproxy"
+  name             = "${var.https_proxy_name}"
   description      = "really a load balancer but listed as an https proxy"
   url_map          = "${google_compute_url_map.https_lb_url_map.self_link}"
   ssl_certificates = ["${var.ssl_certificate}"]
@@ -66,7 +66,7 @@ resource "google_compute_target_https_proxy" "https_lb_proxy" {
 }
 
 resource "google_compute_global_forwarding_rule" "cf_http" {
-  name       = "${var.env_name}-cf-lb-http"
+  name       = "${var.http_forwarding_rule_name}"
   ip_address = "${google_compute_global_address.lb.address}"
   target     = "${google_compute_target_http_proxy.http_lb_proxy.self_link}"
   port_range = "80"
@@ -75,7 +75,7 @@ resource "google_compute_global_forwarding_rule" "cf_http" {
 }
 
 resource "google_compute_global_forwarding_rule" "cf_https" {
-  name       = "${var.env_name}-cf-lb-https"
+  name       = "${var.https_forwarding_rule_name}"
   ip_address = "${google_compute_global_address.lb.address}"
   target     = "${google_compute_target_https_proxy.https_lb_proxy.self_link}"
   port_range = "443"

--- a/modules/load_balancer/regional.tf
+++ b/modules/load_balancer/regional.tf
@@ -1,17 +1,20 @@
+locals {
+  count_regional = "${(!var.global && var.count > 0 ) ? 1 : 0}"
+}
 resource "google_compute_address" "lb" {
-  name = "${var.env_name}-${var.name}-address"
+  name = "${var.name}-address"
 
-  count = "${var.count}"
+  count = "${local.count_regional}"
 }
 
 resource "google_compute_forwarding_rule" "lb" {
-  name        = "${var.env_name}-${var.name}-lb-${count.index}"
+  name        = "${var.name}-lb-${count.index}"
   ip_address  = "${google_compute_address.lb.address}"
   target      = "${google_compute_target_pool.lb.self_link}"
   port_range  = "${element(var.forwarding_rule_ports, count.index)}"
   ip_protocol = "TCP"
 
-  count = "${var.count > 0 ? length(var.forwarding_rule_ports) : 0}"
+  count = "${local.count_regional > 0 ? length(var.forwarding_rule_ports) : 0}"
 }
 
 resource "google_compute_target_pool" "lb" {
@@ -19,5 +22,5 @@ resource "google_compute_target_pool" "lb" {
 
   health_checks = ["${google_compute_http_health_check.lb.*.name}"]
 
-  count = "${var.count}"
+  count = "${local.count_regional}"
 }

--- a/modules/load_balancer/shared.tf
+++ b/modules/load_balancer/shared.tf
@@ -1,10 +1,10 @@
 locals {
-  firewall    = "${length(var.ports) > 0}"
+  firewall    = "${length(var.ports) > 0 && var.count > 0}"
   target_tags = ["${var.lb_name}", "${var.optional_target_tag}"]
 }
 
 resource "google_compute_http_health_check" "lb" {
-  name                = "${var.env_name}-${var.name}-health-check"
+  name                = "${var.name}-health-check"
   port                = "${var.health_check_port}"
   request_path        = "/health"
   check_interval_sec  = "${var.health_check_interval}"
@@ -12,11 +12,11 @@ resource "google_compute_http_health_check" "lb" {
   healthy_threshold   = "${var.health_check_healthy_threshold}"
   unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
 
-  count = "${var.health_check ? 1 : 0}"
+  count = "${var.health_check && var.count > 0 ? 1 : 0}"
 }
 
 resource "google_compute_firewall" "health_check" {
-  name    = "${var.env_name}-${var.name}-health-check"
+  name    = "${var.name}-health-check"
   network = "${var.network}"
 
   allow {
@@ -28,11 +28,11 @@ resource "google_compute_firewall" "health_check" {
 
   target_tags = ["${compact(local.target_tags)}"]
 
-  count = "${var.health_check ? 1 : 0}"
+  count = "${var.health_check && var.count > 0 ? 1 : 0}"
 }
 
 resource "google_compute_firewall" "lb" {
-  name    = "${var.env_name}-${var.name}-firewall"
+  name    = "${var.name}-firewall"
   network = "${var.network}"
 
   allow {

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -65,3 +65,30 @@ variable "ssl_certificate" {
 variable "optional_target_tag" {
   default = ""
 }
+
+## legacy
+
+variable "url_map_name" {
+  type = "string"
+  default = ""
+}
+
+variable "http_proxy_name" {
+  type = "string"
+  default = ""
+}
+
+variable "https_proxy_name" {
+  type = "string"
+  default = ""
+}
+
+variable "http_forwarding_rule_name" {
+  type = "string"
+  default = ""
+}
+
+variable "https_forwarding_rule_name" {
+  type = "string"
+  default = ""
+}

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -1,8 +1,8 @@
 // Modify dns records to resolve to the ha proxy when in internetless mode.
 locals {
   haproxy_static_ip = "${cidrhost(google_compute_subnetwork.pas.ip_cidr_range, -20)}"
-  cf_address        = "${var.global_lb > 0 ? module.gorouter.global_address : module.gorouter.address}"
-  cf_ws_address     = "${var.global_lb > 0 ? module.websocket.address : module.gorouter.address}"
+  cf_address        = "${var.global_lb ? module.gorouter.global_address : module.gorouter.address}"
+  cf_ws_address     = "${var.global_lb ? module.websocket.address : module.gorouter.address}"
 }
 
 resource "google_dns_record_set" "wildcard-sys-dns" {
@@ -69,7 +69,7 @@ resource "google_dns_record_set" "tcp-dns" {
   name = "tcp.${var.dns_zone_dns_name}"
   type = "A"
   ttl  = 300
-
+  count = "${var.create_tcp_router ? 1 : 0}"
   managed_zone = "${var.dns_zone_name}"
 
   rrdatas = ["${var.internetless ? local.haproxy_static_ip : module.tcprouter.address}"]

--- a/modules/pas/lb.tf
+++ b/modules/pas/lb.tf
@@ -2,7 +2,7 @@ module "ssh-lb" {
   source = "../load_balancer"
 
   env_name = "${var.env_name}"
-  name     = "ssh"
+  name     = "${var.env_name}-ssh"
 
   global  = false
   count   = 1
@@ -19,10 +19,16 @@ module "gorouter" {
   source = "../load_balancer"
 
   env_name = "${var.env_name}"
-  name     = "gorouter"
+  name     = "${var.env_name}-gorouter"
 
-  global          = "${var.global_lb}"
-  count           = "${var.global_lb > 0 ? 0 : 1}"
+  global                     = "${var.global_lb}"
+  url_map_name               = "${var.env_name}-cf-http"
+  http_proxy_name            = "${var.env_name}-httpproxy"
+  https_proxy_name           = "${var.env_name}-httpsproxy"
+  http_forwarding_rule_name  = "${var.env_name}-cf-lb-http"
+  https_forwarding_rule_name = "${var.env_name}-cf-lb-https"
+
+  count           = "1"
   network         = "${var.network}"
   zones           = "${var.zones}"
   ssl_certificate = "${var.ssl_certificate}"
@@ -39,17 +45,18 @@ module "gorouter" {
   health_check_timeout             = 3
   health_check_healthy_threshold   = 6
   health_check_unhealthy_threshold = 3
+
 }
 
 module "websocket" {
   source = "../load_balancer"
 
   env_name = "${var.env_name}"
-  name     = "websocket"
+  name     = "${var.env_name}-websocket"
 
   global  = false
   network = "${var.network}"
-  count   = "${var.global_lb}"
+  count   = "${var.global_lb ? 1 : 0}"
 
   ports                 = ["80", "443"]
   lb_name               = "${var.env_name}-cf-ws"
@@ -67,11 +74,11 @@ module "tcprouter" {
   source = "../load_balancer"
 
   env_name = "${var.env_name}"
-  name     = "tcprouter"
+  name     = "${var.env_name}-tcprouter"
 
   global  = false
   network = "${var.network}"
-  count   = 1
+  count   = "${var.create_tcp_router ? 1 : 0}"
 
   ports                 = ["1024-65535"]
   lb_name               = "${var.env_name}-cf-tcp"

--- a/modules/pas/lb.tf
+++ b/modules/pas/lb.tf
@@ -36,7 +36,7 @@ module "gorouter" {
   ports = ["80", "443"]
 
   optional_target_tag   = "${var.isoseg_lb_name}"
-  lb_name               = "${var.env_name}-${var.global_lb > 0 ? "httpslb" : "tcplb"}"
+  lb_name               = "${var.env_name}-${var.global_lb ? "httpslb" : "tcplb"}"
   forwarding_rule_ports = ["80", "443"]
 
   health_check                     = true

--- a/modules/pas/outputs.tf
+++ b/modules/pas/outputs.tf
@@ -11,7 +11,7 @@ output "apps_domain" {
 }
 
 output "tcp_domain" {
-  value = "${replace(google_dns_record_set.tcp-dns.name, "/\\.$/", "")}"
+  value = "${replace(element(concat(google_dns_record_set.tcp-dns.*.name, list("")), 0), "/\\.$/", "")}"
 }
 
 output "buildpacks_bucket" {

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -40,6 +40,8 @@ variable "zones" {
 
 variable "create_gcs_buckets" {}
 
+variable "create_tcp_router" {}
+
 variable "buckets_location" {}
 
 variable "ssl_certificate" {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -75,6 +75,7 @@ module "pas" {
   internetless       = "${var.internetless}"
   global_lb          = "${var.global_lb}"
   create_gcs_buckets = "${var.create_gcs_buckets}"
+  create_tcp_router  = "${var.create_tcp_router}"
   buckets_location   = "${var.buckets_location}"
 
   network           = "${module.infra.network}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -17,7 +17,7 @@ variable "buckets_location" {
 
 variable "global_lb" {
   description = "Use global load balancers for CF instead regional load balancers"
-  default     = 1
+  default     = true
 }
 
 variable "infrastructure_cidr" {
@@ -104,6 +104,11 @@ variable "external_database" {
 variable "internetless" {
   description = "When set to true, all traffic going outside the 10.* network is denied."
   default     = false
+}
+
+variable "create_tcp_router" {
+  description = "Create google load balancer for tcp router"
+  default     = true
 }
 
 ///******************


### PR DESCRIPTION
this is related to #134 
This PR is making the load_balancer module more flexible by:
* allowing to have multiple global lbs
* making tcp router optional (default is true)
* using count straight forward

Variables `url_map_name`, `http_proxy_name`, `https_proxy_name`, `http_forwarding_rule_name` and `https_forwarding_rule_name` were introduced to keep it backwards compatible.

Therefore all existing objects and names are kept, hence no update to existing deployments is required!

if merged, I would make consecutive PRs for adding an optional LB for service mesh ([service mesh branch](https://github.com/vchrisb/terraforming-gcp/tree/service_mesh)) and refactor isolation segment module to also use the load_balancer module ([isoseg branch](https://github.com/vchrisb/terraforming-gcp/tree/refactor_isoseg_lb)).