### PR TITLE
Open metric scraper port (9100) to isoseg

### DIFF
--- a/modules/isolation_segment/firewalls.tf
+++ b/modules/isolation_segment/firewalls.tf
@@ -71,6 +71,7 @@ resource "google_compute_firewall" "isoseg-cf-ingress" {
       "22",   # SSH for debugging
       "1801", # rep.diego.rep.listen_addr_securable
       "8853", # bosh-dns.health.server.port
+      "9100", # loggr-metric-scraper.scrape_port
     ]
   }
 }


### PR DESCRIPTION
A [recent feature](https://github.com/pivotal/lts-pas-issues/issues/348) in PAS (+ IST, PASW) adds a new metric scraper job to the `syslog_scheduler` VM in PAS, and a new system metrics agent job to every VM. The metric scraper regularly polls the agents for new system metrics. By default, it does this on port 9100. In order for it to collect metrics from VMs in isolation segments, we need to open a port on the firewall from the PAS tile VMs to the isoseg VMs.

EDIT: this feature is scheduled to be a part of PAS 2.6, so we would like to ship PAS 2.6 with a `terraforming-gcp` version that enables this feature on isosegs.

cc @njbennett @mcwumbly 