### PR TITLE
Allow traffic from IST loggr-syslog-agent to PAS binding-cache on port 9000

### DIFF
--- a/modules/isolation_segment/firewalls.tf
+++ b/modules/isolation_segment/firewalls.tf
@@ -136,6 +136,7 @@ resource "google_compute_firewall" "cf-isoseg-egress" {
       "8853",  # bosh-dns.health.server.port
       "8889",  # bbs.diego.bbs.listen_addr
       "8891",  # locket.diego.locket.listen_addr
+      "9000",  # loggr-syslog-binding-cache.external_port
       "9022",  # cloud_controller_ng.cc.external_port
       "9023",  # cloud_controller_ng.cc.tls_port
       "9090",  # cc_uploader.http_port


### PR DESCRIPTION
Loggregator has introduced a new syslog drain system with a new loggr-syslog-agent deployed on replicated diego cells in IST that need to communicate over port 9000 with the binding-cache service in PAS.

In order for it to transfer logs from VMs in isolation segments, we need to open a port on the firewall from the PAS tile VMs to the isoseg VMs.

EDIT: this feature is scheduled to be a part of PAS 2.6, so we would like to ship PAS 2.6 with a terraforming-gcp version that enables this feature on isosegs.