### PR TITLE
Add backup bucket

### DIFF
--- a/modules/pas/outputs.tf
+++ b/modules/pas/outputs.tf
@@ -30,6 +30,10 @@ output "resources_bucket" {
   value = "${element(concat(google_storage_bucket.resources.*.name, list("")), 0)}"
 }
 
+output "backup_bucket" {
+  value = "${element(concat(google_storage_bucket.backup.*.name, list("")), 0)}"
+}
+
 output "ws_router_pool" {
   value = "${module.websocket.name}"
 }

--- a/modules/pas/storage.tf
+++ b/modules/pas/storage.tf
@@ -25,3 +25,10 @@ resource "google_storage_bucket" "resources" {
   force_destroy = true
   count         = "${var.create_gcs_buckets ? 1 : 0}"
 }
+
+resource "google_storage_bucket" "backup" {
+  name          = "${var.project}-${var.env_name}-backup"
+  location      = "${var.buckets_location}"
+  force_destroy = true
+  count         = "${var.create_gcs_buckets ? 1 : 0}"
+}

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -160,6 +160,10 @@ output "resources_bucket" {
   value = "${module.pas.resources_bucket}"
 }
 
+output "backup_bucket" {
+  value = "${module.pas.backup_bucket}"
+}
+
 output "pas_subnet_gateway" {
   value = "${module.pas.pas_subnet_gateway}"
 }


### PR DESCRIPTION
We added support for backing up GCS blobstores in 2.6+, this PR adds the creation of the backup bucket into the terraform scripts.

https://www.pivotaltracker.com/story/show/158789077

Co-authored-by: Jake Klein <jklein@pivotal.io>