### PR TITLE
`opsman_image_url` is actually optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ SERVICE_ACCOUNT_KEY
 - project: **(required)** ID for your GCP project.
 - region: **(required)** Region in which to create resources (e.g. us-central1)
 - zones: **(required)** Zones in which to create resources. Must be within the given region. Currently you must specify exactly 3 unique Zones for this terraform configuration to work. (e.g. [us-central1-a, us-central1-b, us-central1-c])
-- opsman\_image\_url **(required)** Source URL of the Ops Manager image you want to boot.
+- opsman\_image\_url **(optional)** Source URL of the Ops Manager image you want to boot.
 - service\_account\_key: **(required)** Contents of your service account key file generated using the `gcloud iam service-accounts keys create` command.
 - dns\_suffix: **(required)** Domain to add environment subdomain to (e.g. foo.example.com). Trailing dots are not supported.
 - buckets\_location: **(optional)** Loction in which to create buckets. Defaults to US.


### PR DESCRIPTION
Release 0.74.0 made `opsman_image_url` optional, so the README should reflect that.