### PR TITLE
Updated Ops Manager DNS entry

### DIFF
--- a/modules/ops_manager/dns.tf
+++ b/modules/ops_manager/dns.tf
@@ -1,5 +1,5 @@
 resource "google_dns_record_set" "ops-manager-dns" {
-  name = "pcf.${var.dns_zone_dns_name}"
+  name = "ops-manager.${var.dns_zone_dns_name}"
   type = "A"
   ttl  = 300
 


### PR DESCRIPTION
"pcf" is not an accurate DNS name for Ops Manager to have, for quite some time "opsman" was used in things such as `pcf-pipelines`, the new convention though is to use `ops-manager` in things such as platform automation and such so we should probably default to that instead.