### PR TITLE
Open port in Iso Seg firewall for routing API's mTLS

### DIFF
--- a/modules/isolation_segment/firewalls.tf
+++ b/modules/isolation_segment/firewalls.tf
@@ -118,6 +118,7 @@ resource "google_compute_firewall" "cf-isoseg-egress" {
 
     ports = [
       "3000",  # routing-api.routing_api.port
+      "3001",  # routing-api.routing_api.mtls_port
       "3457",  # loggregator_agent.listening_port
       "4003",  # vxlan-policy-agent.policy_server.internal_listen_port
       "4103",  # silk-controller.listen_port


### PR DESCRIPTION
Related Story: [#171112674](https://www.pivotaltracker.com/story/show/171112674)